### PR TITLE
Fix bug when widget.klass is NonType

### DIFF
--- a/collective/z3cform/datagridfield/datagridfieldobject_input_block.pt
+++ b/collective/z3cform/datagridfield/datagridfieldobject_input_block.pt
@@ -8,7 +8,7 @@
     <td class="datagridwidget-block-edit-cell">
         <tal:block tal:repeat="widget view/subform/widgets/values">
 
-            <div tal:attributes="class python:'datagridwidget-block-' + widget.id + ' ' + widget.klass + ' datagridwidget-widget-' + widget.field.__name__ + ' ' + (widget.mode == 'hidden' and 'datagridwidget-hidden-data' or 'datagridwidget-block')">
+            <div tal:define="klass python: widget.klass or ''" tal:attributes="class python:'datagridwidget-block-' + widget.id + ' ' + klass + ' datagridwidget-widget-' + widget.field.__name__ + ' ' + (widget.mode == 'hidden' and 'datagridwidget-hidden-data' or 'datagridwidget-block')">
                 <div class="label">
                     <label tal:attributes="for widget/id">
                         <span i18n:translate=""

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,7 +3,7 @@ Changelog
 
 1.2 (unreleased)
 ----------------
-
+- Fix bug for widget.klass is NonType in the block view when defining the class for the field. 
 - Allow deletion of last row in non-auto-append mode.
   [gaudenz]
 


### PR DESCRIPTION
There is a bug when the widget.klass in NonType and it tries to render the page. This allows for klass to exist if it is there and not if it is not defined. I break down the error here in this issue: https://github.com/collective/collective.z3cform.datagridfield/issues/34
